### PR TITLE
Normalize relative path arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,14 +138,14 @@ enum CacheAction {
 
 /// Derive the project root.  Priority:
 /// 1. Explicit --root flag
-/// 2. Walk up from an absolute path argument to find .git
+/// 2. Walk up from a path argument to find .git
 /// 3. Walk up from CWD
 fn resolve_root(explicit: &Option<PathBuf>, path_hint: Option<&Path>) -> PathBuf {
-    if let Some(p) = explicit { return p.clone(); }
-    if let Some(hint) = path_hint
-        && hint.is_absolute()
-    {
-        return util::git::find_project_root(hint);
+    if let Some(p) = explicit {
+        return util::path::absolute_normalize(p);
+    }
+    if let Some(hint) = path_hint {
+        return util::git::find_project_root(&util::path::absolute_normalize(hint));
     }
     let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     util::git::find_project_root(&cwd)
@@ -178,9 +178,7 @@ fn main() {
         Commands::Overview { ref path, full } => {
             let root = resolve_root(&cli.root, Some(path));
             let idx = index::Index::load_or_build(&root);
-            let abs = if path.is_absolute() { path.clone() } else {
-                env::current_dir().unwrap_or_else(|_| root.clone()).join(path)
-            };
+            let abs = util::path::absolute_normalize(path);
             if abs.is_dir() {
                 query::dir_overview(&idx, path, full, cli.no_tests, cli.json, &resolve_pagination(None))
             } else {

--- a/src/query.rs
+++ b/src/query.rs
@@ -861,13 +861,9 @@ fn resolve_file_filter<'a>(
 /// Make a path relative to the project root if it's absolute,
 /// or resolve it from cwd if relative.
 fn make_relative(path: &Path, root: &Path) -> PathBuf {
-    if path.is_absolute() {
-        path.strip_prefix(root).unwrap_or(path).to_path_buf()
-    } else {
-        let cwd = std::env::current_dir().unwrap_or_default();
-        let abs = cwd.join(path);
-        abs.strip_prefix(root).unwrap_or(path).to_path_buf()
-    }
+    let abs = crate::util::path::absolute_normalize(path);
+    let root = crate::util::path::absolute_normalize(root);
+    abs.strip_prefix(&root).unwrap_or(&abs).to_path_buf()
 }
 
 #[cfg(test)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,3 @@
 pub mod git;
 pub mod glob;
+pub mod path;

--- a/src/util/path.rs
+++ b/src/util/path.rs
@@ -1,0 +1,43 @@
+use std::path::{Component, Path, PathBuf};
+
+pub fn absolute_normalize(path: &Path) -> PathBuf {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_default().join(path)
+    };
+    normalize(&abs)
+}
+
+fn normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => match out.components().next_back() {
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                }
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => out.push(component.as_os_str()),
+            },
+            Component::Normal(_) | Component::RootDir | Component::Prefix(_) => {
+                out.push(component.as_os_str());
+            }
+        }
+    }
+    if out.as_os_str().is_empty() { PathBuf::from(".") } else { out }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize;
+    use std::path::Path;
+
+    #[test]
+    fn normalizes_parent_components() {
+        assert_eq!(normalize(Path::new("/repo/child/..")), Path::new("/repo"));
+        assert_eq!(normalize(Path::new("child/../src/lib.rs")), Path::new("src/lib.rs"));
+        assert_eq!(normalize(Path::new("../src")), Path::new("../src"));
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -435,6 +435,76 @@ fn overview_directory_root() {
 }
 
 #[test]
+fn overview_parent_path_switches_root_from_nested_repo() {
+    let dir = temp_project(&[
+        ("src/parent.rs", "pub fn parent_fn() {}\n"),
+        ("child/src/child.rs", "pub fn child_fn() {}\n"),
+    ]);
+    std::fs::create_dir(dir.path().join("child/.git")).unwrap();
+
+    let out = cx_in(&dir.path().join("child")).args(["overview", "../"]).output().unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("src/"), "should show parent project src dir: {stdout}");
+    assert!(stdout.contains("child/"), "should show child dir under parent root: {stdout}");
+}
+
+#[test]
+fn explicit_root_accepts_relative_parent_overview_path() {
+    let dir = temp_project(&[
+        ("src/parent.rs", "pub fn parent_fn() {}\n"),
+        ("child/src/child.rs", "pub fn child_fn() {}\n"),
+    ]);
+    std::fs::create_dir(dir.path().join("child/.git")).unwrap();
+
+    let out = cx_in(&dir.path().join("child"))
+        .args(["--root", "..", "overview", "../"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("src/"), "should show parent project src dir: {stdout}");
+}
+
+#[test]
+fn explicit_relative_root_is_normalized() {
+    let dir = temp_project(&[
+        ("src/lib.rs", "pub fn alpha() {}\n"),
+        ("src/nested/mod.rs", "pub fn nested() {}\n"),
+    ]);
+
+    let out = cx_in(&dir.path().join("src"))
+        .args(["--root", "..", "overview", "."])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("lib.rs"), "should describe cwd relative to normalized root: {stdout}");
+    assert!(stdout.contains("nested/"), "should include nested src dir: {stdout}");
+}
+
+#[test]
+fn overview_accepts_dotdot_path_to_sibling_directory() {
+    let dir = temp_project(&[
+        ("src/lib.rs", "pub fn alpha() {}\n"),
+        ("src/util.rs", "pub fn gamma() {}\n"),
+    ]);
+
+    let out = cx_in(&dir.path().join("src"))
+        .args(["overview", "./../src"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("alpha"), "should find symbols through normalized path: {stdout}");
+    assert!(stdout.contains("gamma"), "should find sibling file through normalized path: {stdout}");
+}
+
+#[test]
 fn overview_directory_includes_tests_by_default() {
     let dir = temp_project(&[
         ("src/app.ts", "export function main() {}\n"),
@@ -697,6 +767,49 @@ fn dir_project() -> tempfile::TempDir {
         ("src/util.rs", "pub fn gamma() {}\n"),
         ("tests/test_main.rs", "fn test_alpha() {}\n"),
     ])
+}
+
+#[test]
+fn symbols_file_accepts_dotdot_path() {
+    let dir = dir_project();
+    let out = cx_in(&dir.path().join("src"))
+        .args(["symbols", "--file", "../src/lib.rs", "--name", "alpha"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("alpha"), "should find symbol through normalized file path: {stdout}");
+}
+
+#[test]
+fn definition_from_accepts_dotdot_path() {
+    let dir = dir_project();
+    let out = cx_in(&dir.path().join("src"))
+        .args(["definition", "--name", "alpha", "--from", "../src/lib.rs"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("pub fn alpha()"), "should find definition through normalized from path: {stdout}");
+}
+
+#[test]
+fn references_file_accepts_dotdot_path() {
+    let dir = temp_project(&[
+        ("src/a.rs", "pub struct Foo;\nfn use_foo(f: Foo) {}\n"),
+        ("src/b.rs", "use crate::Foo;\nfn bar(f: Foo) {}\n"),
+    ]);
+    let out = cx_in(&dir.path().join("src"))
+        .args(["references", "--name", "Foo", "--file", "../src/a.rs", "--context"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(stdout.contains("src/a.rs"), "should find refs through normalized file path: {stdout}");
+    assert!(!stdout.contains("src/b.rs"), "should not include unselected file: {stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Normalize relative and explicit root paths before project-root discovery.
- Handle `.` and `..` consistently across overview, symbols, definition, and references.
- Add focused unit and integration coverage for nested repositories and relative parent paths.

## Root cause

Relative path arguments were resolved inconsistently: root discovery only considered absolute hints, while query filters joined paths without lexically normalizing `.` and `..` components. This could select the wrong repository or fail to match indexed files.

## User impact

Commands now work predictably from subdirectories and nested repositories when paths contain `.` or `..`.

## Validation

- `cargo test` — 213 passed
- `cargo clippy --all-targets -- -D warnings`
- `git diff --cached --check`